### PR TITLE
(feat/loginfallback) Fallback to redirect if popup fails

### DIFF
--- a/src/actions/authActions.js
+++ b/src/actions/authActions.js
@@ -23,7 +23,14 @@ export function login(provider) {
 
     baseRef.authWithOAuthPopup(provider, (error, authData) => {
       if (error) {
-        dispatch(_loginFailure(error));
+        if (error.code === 'TRANSPORT_UNAVAILABLE') {
+          // Fallback to redirect: We redirect then come back to page where we started with session
+          ref.authWithOAuthRedirect(provider, function(redirectError) {
+            dispatch(_loginFailure(redirectError));
+          });
+        } else {
+          dispatch(_loginFailure(error));
+        }
       } else {
         _loginOrSignupUser(authData, dispatch);
       }


### PR DESCRIPTION
If we get transport error fallback to a redirect for login

1) https://www.firebase.com/docs/web/guide/user-auth.html

2) redirect approach gets session then gets back to the page: https://www.firebase.com/docs/web/api/firebase/authwithoauthredirect.html
