### PR TITLE
(fix) Fix typo on private memory flag

### DIFF
--- a/src/components/CreateMemoryModal.js
+++ b/src/components/CreateMemoryModal.js
@@ -71,7 +71,7 @@ export default class CreateMemoryModal extends React.Component {
       data = this.refs.surface.getDOMNode().toDataURL();
     }
 
-    this.props.sendMemory({data: data, title: title, type: this.props.modalType}, priv.checked);
+    this.props.sendMemory({data: data, title: title, type: this.props.modalType}, priv);
     this.closeModal();
   }
 


### PR DESCRIPTION
There was a minor typo that prevented the private flag from being set on new memories
